### PR TITLE
Shellcode injection works.

### DIFF
--- a/dbg.hpp
+++ b/dbg.hpp
@@ -107,8 +107,8 @@ class Debugger {
 private:
   std::string filename;
   ELF* elf;
+  ELF* libc;
 
-  //user_regs_struct regs;
   Registers *regs;
   pid_t proc;
   int status;
@@ -118,9 +118,6 @@ private:
   std::vector<MapEntry> vmmap;
   std::unordered_map<std::string, const ELF*> elf_table;
 
-  //History program_history;
-  //std::vector<Registers> register_log;
-  //std::vector<std::unordered_map<uint64_t, uint8_t*>> mem_log;
   ExecHistory program_history;
 
   arch_t arch;

--- a/main.cpp
+++ b/main.cpp
@@ -232,6 +232,14 @@ int main(int argc, char *argv[]) {
         dbg.reset();
       }*/
       dbg.run();
+    } else if (cmd.cmd == "g" || cmd.cmd == "goto") {
+      if (cmd.args.size() == 2) {
+        uint32_t n = std::strtol(cmd.args[1].c_str(), NULL, 10);
+        std::cout << "trying to restore nr. " << n << std::endl;
+        
+        dbg.restore_state(n); 
+      }
+
     } else if (cmd.cmd == "log") {
       dbg.log_state(); 
     } else if (cmd.cmd == "b") {


### PR DESCRIPTION
The debugger now calls malloc on startup (_start function in target). Heap will be present for all log states and therefor time travel debugging is now more stable. Shellcode injection might also be useful for "from scratch" process creation when using attach feature.